### PR TITLE
fix out of range error

### DIFF
--- a/utxomerger/merge_utxo.py
+++ b/utxomerger/merge_utxo.py
@@ -117,7 +117,8 @@ def main():
         # utxo_mergelist.append(utxolist[i])
         for i in range(loops * merge_size,
                        ((loops + 1) * merge_size) if (loops * merge_size) < len(utxolist) else len(utxolist)):
-            utxo_mergelist.append(utxolist[i])
+            if i < len(utxolist):
+                utxo_mergelist.append(utxolist[i])
 
         # print(loops*merge_size, ", ", ((loops+1)*merge_size) if (loops*merge_size) < len(utxolist) else len(utxolist))
         print('this is the {} times to merge utxos. -----begin'.format(loops + 1))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "btmspanner.py", line 13, in <module>
    sys.exit(merge_utxo.main())
  File "D:\Users\fozzy\Downloads\bytom-spanner\utxomerger\merge_utxo.py", line 121, in main
    utxo_mergelist.append(utxolist[i])
```